### PR TITLE
#161340181 Enable liking and disliking an article

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -20,6 +20,15 @@ class Article(models.Model):
     tagList = TaggableManager(blank=True)
     slug = models.SlugField(max_length=255, unique=True)
     image = models.TextField(null=True, blank=True)
+
+    @property
+    def likescount(self):
+        return ArticleLikes.objects.filter(article_like=True).count()
+
+    @property
+    def dislikescount(self):
+        return ArticleLikes.objects.filter(article_like=False).count()
+
     objects = models.Manager()
 
 class BookmarkingArticles(models.Model):
@@ -27,5 +36,15 @@ class BookmarkingArticles(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     article_id = models.ForeignKey(Article, on_delete=models.CASCADE)
     bookmarked_at = models.DateTimeField(auto_now_add=True)
+    objects = models.Manager()
+
+
+class ArticleLikes(models.Model):
+
+    article = models.ForeignKey(Article, on_delete=models.CASCADE, null=True, blank=True, related_name='article_likes')
+    article_like = models.BooleanField(db_index=True, default=None)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    article_liked_at = models.DateTimeField(auto_now_add=True)
+    article_disliked_at = models.DateTimeField(auto_now=True)
     objects = models.Manager()
 

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -3,11 +3,12 @@ from .views import (
     ListCreateArticleAPIView,
     UpdateDestroyArticleAPIView,
     BookMarkArticleAPIView,
+    LikeArticleAPIView,
 )
 
 urlpatterns = [
     path('', ListCreateArticleAPIView.as_view()),
     path('<slug>', UpdateDestroyArticleAPIView.as_view(), ),
-    path('<slug>/bookmark', BookMarkArticleAPIView.as_view(), )
-
+    path('<slug>/bookmark', BookMarkArticleAPIView.as_view(), ),
+    path('<slug>/likes', LikeArticleAPIView.as_view(), )
 ]

--- a/authors/tests/base_test.py
+++ b/authors/tests/base_test.py
@@ -47,6 +47,18 @@ class BaseTest(TestCase):
                                     "reason" : "this is a plagiarized article"
                                 }
                             }
+        self.article_like_data = {
+                "article": {
+		            "article_like":"True"
+	            }
+        }
+
+
+        self.article_dislike_data = {
+                "article": {
+		            "article_like":"True" 
+	            }
+        }
         
         self.report_data2 = {"report" : 
                                 {
@@ -95,4 +107,12 @@ class BaseTest(TestCase):
     
     def bookmark_article(self):
         return self.client.post(f"/api/articles/{self.slug}/bookmark", **self.headers)
+    def like_article(self):
+        return self.client.post(f"/api/articles/{self.slug}/likes", self.article_like_data, **self.headers)
+    
+    def dislike_article(self):
+        return self.client.post(f"/api/articles/{self.slug}/likes", self.article_dislike_data, **self.headers)
+    
+    def double_like_article(self):
+        return self.client.post(f"/api/articles/{self.slug}/likes", self.article_dislike_data, **self.headers)
     

--- a/authors/tests/test_articles.py
+++ b/authors/tests/test_articles.py
@@ -38,3 +38,18 @@ class BookMarkTest(BaseTest):
         response = self.bookmark_article()
         self.assertEqual(response.status_code, 200)
 
+
+class ArticleLikeTests(BaseTest):
+
+    def test_like_article(self):
+        response = self.like_article()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_dislike_article(self):
+        response = self.dislike_article()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_double_like_article(self):
+        response = self.double_like_article()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+


### PR DESCRIPTION
#### What does this PR do?
Users should be able to like and or dislike articles
#### Description of Task to be completed?
- as a user i should be able to like an article
- as a user i should be able to dislike an article
- when a user likes an article twice, the like is the deleted on the second time.
- tests are written for liking and disliking an article
#### How should this be manually tested?
- git checkout branch `ft-like-and-dislike-articles-161340181`
- runserver using `python manage.py runserver`terminal command
- go to postman and test the endpoint using this url `http://127.0.0.1:8000/api/articles/some-title-949e74bab60d/likes`
#### Any background context you want to provide?
Using facebook as an example, when a user likes a comment, and then likes it again, the like is deleted.
This prevents storing more than one like from one user.
#### What are the relevant pivotal tracker stories?
[#161340181](https://www.pivotaltracker.com/story/show/161340181)
#### Screenshots (if appropriate)
##### Input and return data when an article is liked

<img width="1128" alt="screen shot 2018-11-12 at 15 00 37" src="https://user-images.githubusercontent.com/39129473/48346304-bec19380-e68b-11e8-8526-cec63ac9bb94.png">

##### Input and return data when an article is disliked
<img width="1118" alt="screen shot 2018-11-12 at 14 43 44" src="https://user-images.githubusercontent.com/39129473/48346189-67232800-e68b-11e8-8f5e-018a864d9a5e.png">

#### Questions: