### PR TITLE
#161340181 Fix bug in liking and disliking an article

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -24,19 +24,18 @@ class Article(models.Model):
 
     @property
     def likescount(self):
-        return ArticleLikes.objects.filter(article_like=True).count()
+        return ArticleLikes.objects.filter(article_like=True, article=self).count()
 
     @property
     def dislikescount(self):
-        return ArticleLikes.objects.filter(article_like=False).count()
-
-
-    objects = models.Manager()
+        return ArticleLikes.objects.filter(article_like=False, article=self).count()
     
     @property
     def comments(self):
         comments = Comment.objects.filter(article=self.id).values()
         return [ dict(comment) for comment in comments]
+    
+    objects = models.Manager()
 
 
 class BookmarkingArticles(models.Model):
@@ -64,9 +63,6 @@ class Rating(models.Model):
     updated_at = models.DateField(auto_now=True)
 
 
-
-
-
 class FavoriteArticle(models.Model):
     article = models.ForeignKey(Article, on_delete=models.CASCADE)
     favorite_status = models.BooleanField(default=False)
@@ -87,5 +83,4 @@ class Thread(models.Model):
     comment = models.ForeignKey(Comment, on_delete=models.CASCADE)
     createdAt = models.DateTimeField(auto_now_add=True)
     updatedAt = models.DateTimeField(auto_now=True)
-    
 

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -143,9 +143,6 @@ class FavoriteArticlesSerializer(serializers.ModelSerializer):
         model = FavoriteArticle
 
         fields = ('article', 'favorite_status', 'author', 'favorited_at', 'last_updated_at')
-        
-        
-        
 
 
 class CreateCommentAPIViewSerializer(serializers.ModelSerializer):

--- a/authors/tests/base_test.py
+++ b/authors/tests/base_test.py
@@ -221,5 +221,3 @@ class BaseTest(TestCase):
         return self.client.post(f"/api/articles/{self.wrong_slug}/comments", 
         self.comment_data, **self.headers)  
 
-
-

--- a/authors/tests/test_articles.py
+++ b/authors/tests/test_articles.py
@@ -52,6 +52,7 @@ class ArticleLikeTests(BaseTest):
     def test_double_like_article(self):
         response = self.double_like_article()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 class TestRating(BaseTest):
 
     def test_post_user_cannot_rate_his_own_article(self):


### PR DESCRIPTION
#### What does this PR do?
Fix  bug in liking and disliking articles

#### Description of Task to be completed?
- `Before`:  When an article is liked or disliked, and then all articles are returned, the likes count for all articles would increase or decrease by one depending on the action.
- `After`: Now every article is retrieved with its  actual likes count and dislikes

#### Screenshots 
A screenshot showing how the endpoint returns the articles now

<img width="530" alt="screenshot 2018-11-19 at 10 08 01" src="https://user-images.githubusercontent.com/39129473/48691280-09d72b80-ebe3-11e8-9a02-098d231211fe.png">